### PR TITLE
EESD-29: Add support for extracting multiple points accounts attributes

### DIFF
--- a/jest.integration.config.js
+++ b/jest.integration.config.js
@@ -16,4 +16,5 @@ module.exports = {
     '<rootDir>/examples/generic-connector/src/**/*.ts',
   ],
   coverageDirectory: '<rootDir>/coverage/integration',
+  setupFilesAfterEnv: ['<rootDir>/test/jest.setup.ts'],
 };

--- a/jest.unit.config.js
+++ b/jest.unit.config.js
@@ -16,4 +16,5 @@ module.exports = {
     '<rootDir>/examples/generic-connector/src/**/*.ts',
   ],
   coverageDirectory: '<rootDir>/coverage/unit',
+  setupFilesAfterEnv: ['<rootDir>/test/jest.setup.ts'],
 };

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@eagleeye-solutions/integration-events-common",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Eagle Eye CDP connector common functionality",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
   "scripts": {
     "test": "npm run test:unit && npm run test:integration",
-    "test:unit": "jest -c jest.unit.config.js",
-    "test:integration": "npm run test:integration:examples:generic-connector",
-    "test:integration:examples:generic-connector": "PUBSUB_EMULATOR_HOST=\"${PUBSUB_EMULATOR_HOST:=localhost:$(npm run --silent gcp:pubsub:getPort)}\" jest -c jest.integration.config.js --runInBand",
+    "test:unit": "TZ=UTC NEW_RELIC_APP_NAME=test jest -c jest.unit.config.js",
+    "test:integration": "TZ=UTC NEW_RELIC_APP_NAME=test npm run test:integration:examples:generic-connector",
+    "test:integration:examples:generic-connector": "TZ=UTC NEW_RELIC_APP_NAME=test PUBSUB_EMULATOR_HOST=\"${PUBSUB_EMULATOR_HOST:=localhost:$(npm run --silent gcp:pubsub:getPort)}\" jest -c jest.integration.config.js --runInBand",
     "gcp:pubsub:start": "docker-compose -f examples/generic-connector/test/integration/docker-compose.yaml up -d",
     "gcp:pubsub:getPort": "docker-compose -f examples/generic-connector/test/integration/docker-compose.yaml ps --format json | jq '. | .Publishers[] | select(.TargetPort==8085) | .PublishedPort'",
     "gcp:pubsub:stop": "docker-compose -f examples/generic-connector/test/integration/docker-compose.yaml down",

--- a/src/ee-air/atomic-operations/wallet-account-transaction-entity.ts
+++ b/src/ee-air/atomic-operations/wallet-account-transaction-entity.ts
@@ -71,10 +71,9 @@ export function getPointsAttributesFromWalletAccountTransactionEntity(
     | WalletAccountTransactionEntityUpdateEarnPoints
     | WalletAccountTransactionEntityUpdateRefundDebitPoints,
 ): PointsAttributes {
-  const snapshot =
-    getPointsAccountSnapshotFromWalletAccountTransactionEntity(
-      walletAccountTransactionEntity,
-    );
+  const snapshot = getPointsAccountSnapshotFromWalletAccountTransactionEntity(
+    walletAccountTransactionEntity,
+  );
   return {
     pointsBalance: snapshot.pointsBalance,
   };

--- a/src/ee-air/atomic-operations/wallet-account-transaction-entity.ts
+++ b/src/ee-air/atomic-operations/wallet-account-transaction-entity.ts
@@ -1,6 +1,7 @@
 import {parseISO} from 'date-fns';
 import {
   PointsAttributes,
+  PointsAccountSnapshot,
   CouponAttributes,
   CouponWithValueAttributes,
   StandardSubscriptionAttributes,
@@ -30,13 +31,13 @@ import {
   RedeemedBehavioralActionAttributes,
 } from '../../types';
 
-export function getPointsAttributesFromWalletAccountTransactionEntity(
+export function getPointsAccountSnapshotFromWalletAccountTransactionEntity(
   walletAccountTransactionEntity:
     | WalletAccountTransactionEntityCreatePoints
     | WalletAccountTransactionEntityUpdateCreditPoints
     | WalletAccountTransactionEntityUpdateEarnPoints
     | WalletAccountTransactionEntityUpdateRefundDebitPoints,
-): PointsAttributes {
+): PointsAccountSnapshot {
   const account = walletAccountTransactionEntity.objectValue.account;
   const balances = account.balances;
 
@@ -47,13 +48,36 @@ export function getPointsAttributesFromWalletAccountTransactionEntity(
     balances.current !== undefined
   ) {
     return {
+      accountId: account.accountId,
+      campaignId: account.campaignId,
+      walletId: account.walletId,
       pointsBalance: balances.current,
+      type: account.type,
+      clientType: account.clientType ?? null,
+      status: account.status,
+      state: account.state,
     };
   } else {
     throw new Error(
       'Points balance not available in walletAccountTransactionEntity',
     );
   }
+}
+
+export function getPointsAttributesFromWalletAccountTransactionEntity(
+  walletAccountTransactionEntity:
+    | WalletAccountTransactionEntityCreatePoints
+    | WalletAccountTransactionEntityUpdateCreditPoints
+    | WalletAccountTransactionEntityUpdateEarnPoints
+    | WalletAccountTransactionEntityUpdateRefundDebitPoints,
+): PointsAttributes {
+  const snapshot =
+    getPointsAccountSnapshotFromWalletAccountTransactionEntity(
+      walletAccountTransactionEntity,
+    );
+  return {
+    pointsBalance: snapshot.pointsBalance,
+  };
 }
 
 export function getBehavioralActionAttributesFromWalletAccountTransactionEntity(

--- a/src/ee-air/collect-points-account-snapshots.ts
+++ b/src/ee-air/collect-points-account-snapshots.ts
@@ -30,16 +30,21 @@ export function collectPointsAccountSnapshotsFromAtomicOperations(
 } {
   const byAccountId = new Map<string, PointsAccountSnapshot>();
 
-  for (const op of atomicOperations) {
-    const match =
-      mode === 'pointsCreatesOnly'
-        ? isWalletAccountTransactionEntityCreatePoints(op)
-        : mode === 'pointsUpdatesOnly'
-          ? isWalletAccountTransactionEntityUpdatePoints(op)
-          : isWalletAccountTransactionEntityCreatePoints(op) ||
-            isWalletAccountTransactionEntityUpdatePoints(op);
+  const opMatchesMode = (op: AtomicOperation): boolean => {
+    if (mode === 'pointsCreatesOnly') {
+      return isWalletAccountTransactionEntityCreatePoints(op);
+    }
+    if (mode === 'pointsUpdatesOnly') {
+      return isWalletAccountTransactionEntityUpdatePoints(op);
+    }
+    return (
+      isWalletAccountTransactionEntityCreatePoints(op) ||
+      isWalletAccountTransactionEntityUpdatePoints(op)
+    );
+  };
 
-    if (!match) {
+  for (const op of atomicOperations) {
+    if (!opMatchesMode(op)) {
       continue;
     }
     try {

--- a/src/ee-air/collect-points-account-snapshots.ts
+++ b/src/ee-air/collect-points-account-snapshots.ts
@@ -48,8 +48,9 @@ export function collectPointsAccountSnapshotsFromAtomicOperations(
       continue;
     }
     try {
-      const snap =
-        getPointsAccountSnapshotFromWalletAccountTransactionEntity(op as any);
+      const snap = getPointsAccountSnapshotFromWalletAccountTransactionEntity(
+        op as any,
+      );
       byAccountId.set(snap.accountId, snap);
     } catch {
       // ignore ops without balances

--- a/src/ee-air/collect-points-account-snapshots.ts
+++ b/src/ee-air/collect-points-account-snapshots.ts
@@ -73,3 +73,24 @@ export function collectPointsAccountSnapshotsFromAtomicOperations(
 
   return {pointsAccounts, ...(points ? {points} : {})};
 }
+
+/**
+ * Same data as {@link collectPointsAccountSnapshotsFromAtomicOperations}, shaped for
+ * spreading into outbound event payloads (`pointsAccounts` / `points` only when set).
+ */
+export type PointsSnapshotEventFields = Partial<{
+  pointsAccounts: PointsAccountSnapshot[];
+  points: PointsAttributes;
+}>;
+
+export function pointsSnapshotFieldsForEvent(
+  atomicOperations: readonly AtomicOperation[],
+  mode: CollectPointsSnapshotsMode,
+): PointsSnapshotEventFields {
+  const {pointsAccounts, points} =
+    collectPointsAccountSnapshotsFromAtomicOperations(atomicOperations, mode);
+  return {
+    ...(pointsAccounts.length > 0 ? {pointsAccounts} : {}),
+    ...(points ? {points} : {}),
+  };
+}

--- a/src/ee-air/collect-points-account-snapshots.ts
+++ b/src/ee-air/collect-points-account-snapshots.ts
@@ -1,0 +1,69 @@
+import {
+  AtomicOperation,
+  PointsAccountSnapshot,
+  PointsAttributes,
+} from '../types';
+import {
+  isWalletAccountTransactionEntityCreatePoints,
+  isWalletAccountTransactionEntityUpdatePoints,
+} from './atomic-operations/helpers/wallet-account-transaction-entity-helpers';
+import {getPointsAccountSnapshotFromWalletAccountTransactionEntity} from './atomic-operations/wallet-account-transaction-entity';
+
+export type CollectPointsSnapshotsMode =
+  | 'pointsCreatesOnly'
+  | 'pointsUpdatesOnly'
+  | 'pointsCreatesOrUpdates';
+
+/**
+ * Collects per–POINTS-account snapshots from atomic operations.
+ *
+ * - `pointsAccounts`: unique by `accountId` (last occurrence in event order wins).
+ * - `points` (legacy): sum of the last-seen balance for each unique account —
+ *   providing a total across all loyalty schemes.
+ */
+export function collectPointsAccountSnapshotsFromAtomicOperations(
+  atomicOperations: readonly AtomicOperation[],
+  mode: CollectPointsSnapshotsMode,
+): {
+  pointsAccounts: PointsAccountSnapshot[];
+  points?: PointsAttributes;
+} {
+  const byAccountId = new Map<string, PointsAccountSnapshot>();
+
+  for (const op of atomicOperations) {
+    const match =
+      mode === 'pointsCreatesOnly'
+        ? isWalletAccountTransactionEntityCreatePoints(op)
+        : mode === 'pointsUpdatesOnly'
+          ? isWalletAccountTransactionEntityUpdatePoints(op)
+          : isWalletAccountTransactionEntityCreatePoints(op) ||
+            isWalletAccountTransactionEntityUpdatePoints(op);
+
+    if (!match) {
+      continue;
+    }
+    try {
+      const snap =
+        getPointsAccountSnapshotFromWalletAccountTransactionEntity(op as any);
+      byAccountId.set(snap.accountId, snap);
+    } catch {
+      // ignore ops without balances
+    }
+  }
+
+  const pointsAccounts = Array.from(byAccountId.values()).sort((a, b) =>
+    a.accountId.localeCompare(b.accountId, 'en'),
+  );
+
+  const points: PointsAttributes | undefined =
+    byAccountId.size > 0
+      ? {
+          pointsBalance: pointsAccounts.reduce(
+            (sum, snap) => sum + snap.pointsBalance,
+            0,
+          ),
+        }
+      : undefined;
+
+  return {pointsAccounts, ...(points ? {points} : {})};
+}

--- a/src/ee-air/index.ts
+++ b/src/ee-air/index.ts
@@ -17,4 +17,5 @@ export * from './wallet-account-update';
 export * from './wallet-account-create-scheme';
 export * from './wallet-account-create-campaign';
 export * from './wallet-account-transaction-redeem';
+export * from './collect-points-account-snapshots';
 export * from './types';

--- a/src/ee-air/posconnect-wallet-fulfil.ts
+++ b/src/ee-air/posconnect-wallet-fulfil.ts
@@ -1,7 +1,6 @@
 import {
   EeAirOutboundEvent,
   CouponWithValueAttributes,
-  PointsAttributes,
   TierAttributes,
   TransactionAttributes,
   POSConnectWalletFulfilEventData,
@@ -9,13 +8,12 @@ import {
 import {BaseEventHandlerOpts} from './types';
 import AtomicOperations, {
   isTierMembershipEntity,
-  isWalletAccountTransactionEntityUpdatePoints,
   isWalletAccountTransactionEntityUpdateRedeemEcoupon,
   isWalletTransactionEntityCreateFulfilFulfilled,
   isWalletTransactionEntityUpdateSettleFulfilling,
   isWalletTransactionEntityUpdateSettleSettled,
 } from './atomic-operations';
-import {getPointsAttributesFromWalletAccountTransactionEntity} from './atomic-operations/wallet-account-transaction-entity';
+import {collectPointsAccountSnapshotsFromAtomicOperations} from './collect-points-account-snapshots';
 
 function isInitialPosConnectWalletFulfil(event: EeAirOutboundEvent): boolean {
   if (event.headers.eventName === 'POSCONNECT.WALLET.FULFIL') {
@@ -90,24 +88,19 @@ function getPosConnectWalletFulfilInitialEventData(
   event: EeAirOutboundEvent,
   opts: BaseEventHandlerOpts,
 ): POSConnectWalletFulfilEventData {
+  const {pointsAccounts, points} =
+    collectPointsAccountSnapshotsFromAtomicOperations(
+      event.atomicOperations,
+      'pointsUpdatesOnly',
+    );
+
   let transactionAttributes: TransactionAttributes | null = null;
-  let pointsAttributes: PointsAttributes | null = null;
   let tierAttributes: TierAttributes | null = null;
 
   const redeemedCoupons: CouponWithValueAttributes[] = [];
 
   for (const op of event.atomicOperations) {
-    if (isWalletAccountTransactionEntityUpdatePoints(op)) {
-      try {
-        pointsAttributes =
-          getPointsAttributesFromWalletAccountTransactionEntity(op as any);
-      } catch {
-        // Ignore if balance not available on this op.
-        // By taking the latest POINTS balance observed in the operations list,
-        // we ensure that we always have the most up-to-date balance regardless
-        // of the its type.
-      }
-    } else if (isTierMembershipEntity(op)) {
+    if (isTierMembershipEntity(op)) {
       tierAttributes =
         AtomicOperations.TierMembershipEntity.getTierAttributes(op);
     } else if (isWalletAccountTransactionEntityUpdateRedeemEcoupon(op)) {
@@ -131,7 +124,8 @@ function getPosConnectWalletFulfilInitialEventData(
   }
 
   const posConnectWalletSettleEventData: POSConnectWalletFulfilEventData = {
-    ...(pointsAttributes ? {points: pointsAttributes} : {}),
+    ...(pointsAccounts.length > 0 ? {pointsAccounts} : {}),
+    ...(points ? {points} : {}),
     ...(tierAttributes ? {tier: tierAttributes} : {}),
     ...(transactionAttributes ? {transaction: transactionAttributes} : {}),
     redeemedCoupons,
@@ -147,26 +141,21 @@ function getPosConnectWalletFulfilMiddleEventData(
   event: EeAirOutboundEvent,
   opts: BaseEventHandlerOpts,
 ): POSConnectWalletFulfilEventData {
+  const {pointsAccounts, points} =
+    collectPointsAccountSnapshotsFromAtomicOperations(
+      event.atomicOperations,
+      'pointsUpdatesOnly',
+    );
+
   const transactionAttributes: TransactionAttributes = {
     products: [],
   };
-  let pointsAttributes: PointsAttributes | null = null;
   let tierAttributes: TierAttributes | null = null;
 
   const redeemedCoupons: CouponWithValueAttributes[] = [];
 
   for (const op of event.atomicOperations) {
-    if (isWalletAccountTransactionEntityUpdatePoints(op)) {
-      try {
-        pointsAttributes =
-          getPointsAttributesFromWalletAccountTransactionEntity(op as any);
-      } catch {
-        // Ignore if balance not available on this op.
-        // By taking the latest POINTS balance observed in the operations list,
-        // we ensure that we always have the most up-to-date balance regardless
-        // of the its type.
-      }
-    } else if (isTierMembershipEntity(op)) {
+    if (isTierMembershipEntity(op)) {
       tierAttributes =
         AtomicOperations.TierMembershipEntity.getTierAttributes(op);
     } else if (isWalletAccountTransactionEntityUpdateRedeemEcoupon(op)) {
@@ -215,7 +204,8 @@ function getPosConnectWalletFulfilMiddleEventData(
   }
 
   const posConnectWalletSettleEventData: POSConnectWalletFulfilEventData = {
-    ...(pointsAttributes ? {points: pointsAttributes} : {}),
+    ...(pointsAccounts.length > 0 ? {pointsAccounts} : {}),
+    ...(points ? {points} : {}),
     ...(tierAttributes ? {tier: tierAttributes} : {}),
     ...(transactionAttributes ? {transaction: transactionAttributes} : {}),
     redeemedCoupons,
@@ -231,26 +221,21 @@ function getPosConnectWalletFulfilFinalEventData(
   event: EeAirOutboundEvent,
   opts: BaseEventHandlerOpts,
 ): POSConnectWalletFulfilEventData {
+  const {pointsAccounts, points} =
+    collectPointsAccountSnapshotsFromAtomicOperations(
+      event.atomicOperations,
+      'pointsUpdatesOnly',
+    );
+
   const transactionAttributes: TransactionAttributes = {
     products: [],
   };
-  let pointsAttributes: PointsAttributes | null = null;
   let tierAttributes: TierAttributes | null = null;
 
   const redeemedCoupons: CouponWithValueAttributes[] = [];
 
   for (const op of event.atomicOperations) {
-    if (isWalletAccountTransactionEntityUpdatePoints(op)) {
-      try {
-        pointsAttributes =
-          getPointsAttributesFromWalletAccountTransactionEntity(op as any);
-      } catch {
-        // Ignore if balance not available on this op.
-        // By taking the latest POINTS balance observed in the operations list,
-        // we ensure that we always have the most up-to-date balance regardless
-        // of the its type.
-      }
-    } else if (isTierMembershipEntity(op)) {
+    if (isTierMembershipEntity(op)) {
       tierAttributes =
         AtomicOperations.TierMembershipEntity.getTierAttributes(op);
     } else if (isWalletAccountTransactionEntityUpdateRedeemEcoupon(op)) {
@@ -299,7 +284,8 @@ function getPosConnectWalletFulfilFinalEventData(
   }
 
   const posConnectWalletSettleEventData: POSConnectWalletFulfilEventData = {
-    ...(pointsAttributes ? {points: pointsAttributes} : {}),
+    ...(pointsAccounts.length > 0 ? {pointsAccounts} : {}),
+    ...(points ? {points} : {}),
     ...(tierAttributes ? {tier: tierAttributes} : {}),
     ...(transactionAttributes ? {transaction: transactionAttributes} : {}),
     redeemedCoupons,

--- a/src/ee-air/posconnect-wallet-fulfil.ts
+++ b/src/ee-air/posconnect-wallet-fulfil.ts
@@ -13,7 +13,7 @@ import AtomicOperations, {
   isWalletTransactionEntityUpdateSettleFulfilling,
   isWalletTransactionEntityUpdateSettleSettled,
 } from './atomic-operations';
-import {collectPointsAccountSnapshotsFromAtomicOperations} from './collect-points-account-snapshots';
+import {pointsSnapshotFieldsForEvent} from './collect-points-account-snapshots';
 
 function isInitialPosConnectWalletFulfil(event: EeAirOutboundEvent): boolean {
   if (event.headers.eventName === 'POSCONNECT.WALLET.FULFIL') {
@@ -88,12 +88,6 @@ function getPosConnectWalletFulfilInitialEventData(
   event: EeAirOutboundEvent,
   opts: BaseEventHandlerOpts,
 ): POSConnectWalletFulfilEventData {
-  const {pointsAccounts, points} =
-    collectPointsAccountSnapshotsFromAtomicOperations(
-      event.atomicOperations,
-      'pointsUpdatesOnly',
-    );
-
   let transactionAttributes: TransactionAttributes | null = null;
   let tierAttributes: TierAttributes | null = null;
 
@@ -124,8 +118,10 @@ function getPosConnectWalletFulfilInitialEventData(
   }
 
   const posConnectWalletSettleEventData: POSConnectWalletFulfilEventData = {
-    ...(pointsAccounts.length > 0 ? {pointsAccounts} : {}),
-    ...(points ? {points} : {}),
+    ...pointsSnapshotFieldsForEvent(
+      event.atomicOperations,
+      'pointsUpdatesOnly',
+    ),
     ...(tierAttributes ? {tier: tierAttributes} : {}),
     ...(transactionAttributes ? {transaction: transactionAttributes} : {}),
     redeemedCoupons,
@@ -141,12 +137,6 @@ function getPosConnectWalletFulfilMiddleEventData(
   event: EeAirOutboundEvent,
   opts: BaseEventHandlerOpts,
 ): POSConnectWalletFulfilEventData {
-  const {pointsAccounts, points} =
-    collectPointsAccountSnapshotsFromAtomicOperations(
-      event.atomicOperations,
-      'pointsUpdatesOnly',
-    );
-
   const transactionAttributes: TransactionAttributes = {
     products: [],
   };
@@ -204,8 +194,10 @@ function getPosConnectWalletFulfilMiddleEventData(
   }
 
   const posConnectWalletSettleEventData: POSConnectWalletFulfilEventData = {
-    ...(pointsAccounts.length > 0 ? {pointsAccounts} : {}),
-    ...(points ? {points} : {}),
+    ...pointsSnapshotFieldsForEvent(
+      event.atomicOperations,
+      'pointsUpdatesOnly',
+    ),
     ...(tierAttributes ? {tier: tierAttributes} : {}),
     ...(transactionAttributes ? {transaction: transactionAttributes} : {}),
     redeemedCoupons,
@@ -221,12 +213,6 @@ function getPosConnectWalletFulfilFinalEventData(
   event: EeAirOutboundEvent,
   opts: BaseEventHandlerOpts,
 ): POSConnectWalletFulfilEventData {
-  const {pointsAccounts, points} =
-    collectPointsAccountSnapshotsFromAtomicOperations(
-      event.atomicOperations,
-      'pointsUpdatesOnly',
-    );
-
   const transactionAttributes: TransactionAttributes = {
     products: [],
   };
@@ -284,8 +270,10 @@ function getPosConnectWalletFulfilFinalEventData(
   }
 
   const posConnectWalletSettleEventData: POSConnectWalletFulfilEventData = {
-    ...(pointsAccounts.length > 0 ? {pointsAccounts} : {}),
-    ...(points ? {points} : {}),
+    ...pointsSnapshotFieldsForEvent(
+      event.atomicOperations,
+      'pointsUpdatesOnly',
+    ),
     ...(tierAttributes ? {tier: tierAttributes} : {}),
     ...(transactionAttributes ? {transaction: transactionAttributes} : {}),
     redeemedCoupons,

--- a/src/ee-air/posconnect-wallet-refund.ts
+++ b/src/ee-air/posconnect-wallet-refund.ts
@@ -12,7 +12,7 @@ import AtomicOperations, {
   isWalletAccountTransactionEntityUpdateUnredeemEcoupon,
   isWalletTransactionEntityCreateRefundSettled,
 } from './atomic-operations';
-import {collectPointsAccountSnapshotsFromAtomicOperations} from './collect-points-account-snapshots';
+import {pointsSnapshotFieldsForEvent} from './collect-points-account-snapshots';
 
 /**
  * Returns an array of events derived from a POSCONNECT.WALLET.REFUND event.
@@ -40,12 +40,6 @@ export function getPosConnectWalletRefundEventData(
   event: EeAirOutboundEvent,
   opts: BaseEventHandlerOpts,
 ): POSConnectWalletRefundEventData {
-  const {pointsAccounts, points} =
-    collectPointsAccountSnapshotsFromAtomicOperations(
-      event.atomicOperations,
-      'pointsUpdatesOnly',
-    );
-
   let transactionAttributes: TransactionAttributes | null = null;
   let tierAttributes: TierAttributes | null = null;
 
@@ -100,8 +94,10 @@ export function getPosConnectWalletRefundEventData(
   }
 
   const posConnectWalletRefundEventData: POSConnectWalletRefundEventData = {
-    ...(pointsAccounts.length > 0 ? {pointsAccounts} : {}),
-    ...(points ? {points} : {}),
+    ...pointsSnapshotFieldsForEvent(
+      event.atomicOperations,
+      'pointsUpdatesOnly',
+    ),
     ...(tierAttributes ? {tier: tierAttributes} : {}),
     ...(transactionAttributes ? {transaction: transactionAttributes} : {}),
     redeemedCoupons,

--- a/src/ee-air/posconnect-wallet-refund.ts
+++ b/src/ee-air/posconnect-wallet-refund.ts
@@ -1,20 +1,18 @@
 import {
   CouponWithValueAttributes,
   EeAirOutboundEvent,
-  PointsAttributes,
   TierAttributes,
   TransactionAttributes,
 } from '..';
 import {POSConnectWalletRefundEventData} from '../types';
 import {BaseEventHandlerOpts} from './types';
-import {getPointsAttributesFromWalletAccountTransactionEntity} from './atomic-operations/wallet-account-transaction-entity';
 import AtomicOperations, {
   isTierMembershipEntity,
-  isWalletAccountTransactionEntityUpdatePoints,
   isWalletAccountTransactionEntityUpdateRedeemEcoupon,
   isWalletAccountTransactionEntityUpdateUnredeemEcoupon,
   isWalletTransactionEntityCreateRefundSettled,
 } from './atomic-operations';
+import {collectPointsAccountSnapshotsFromAtomicOperations} from './collect-points-account-snapshots';
 
 /**
  * Returns an array of events derived from a POSCONNECT.WALLET.REFUND event.
@@ -42,25 +40,20 @@ export function getPosConnectWalletRefundEventData(
   event: EeAirOutboundEvent,
   opts: BaseEventHandlerOpts,
 ): POSConnectWalletRefundEventData {
+  const {pointsAccounts, points} =
+    collectPointsAccountSnapshotsFromAtomicOperations(
+      event.atomicOperations,
+      'pointsUpdatesOnly',
+    );
+
   let transactionAttributes: TransactionAttributes | null = null;
-  let pointsAttributes: PointsAttributes | null = null;
   let tierAttributes: TierAttributes | null = null;
 
   const redeemedCoupons: CouponWithValueAttributes[] = [];
   const unredeemedCoupons: CouponWithValueAttributes[] = [];
 
   for (const op of event.atomicOperations) {
-    if (isWalletAccountTransactionEntityUpdatePoints(op)) {
-      try {
-        pointsAttributes =
-          getPointsAttributesFromWalletAccountTransactionEntity(op as any);
-      } catch {
-        // Ignore if balance not available on this op.
-        // By taking the latest POINTS balance observed in the operations list,
-        // we ensure that we always have the most up-to-date balance regardless
-        // of the its type.
-      }
-    } else if (isTierMembershipEntity(op)) {
+    if (isTierMembershipEntity(op)) {
       tierAttributes =
         AtomicOperations.TierMembershipEntity.getTierAttributes(op);
     } else if (isWalletAccountTransactionEntityUpdateRedeemEcoupon(op)) {
@@ -107,7 +100,8 @@ export function getPosConnectWalletRefundEventData(
   }
 
   const posConnectWalletRefundEventData: POSConnectWalletRefundEventData = {
-    ...(pointsAttributes ? {points: pointsAttributes} : {}),
+    ...(pointsAccounts.length > 0 ? {pointsAccounts} : {}),
+    ...(points ? {points} : {}),
     ...(tierAttributes ? {tier: tierAttributes} : {}),
     ...(transactionAttributes ? {transaction: transactionAttributes} : {}),
     redeemedCoupons,

--- a/src/ee-air/posconnect-wallet-settle.ts
+++ b/src/ee-air/posconnect-wallet-settle.ts
@@ -7,12 +7,11 @@ import {
   CouponWithValueAttributes,
   POSConnectWalletSettleEventData,
 } from '../types';
-import {isTierMembershipEntity} from './atomic-operations';
-import {
+import AtomicOperations, {
+  isTierMembershipEntity,
   isWalletTransactionEntityUpdateSettleSettled,
   isWalletAccountTransactionEntityUpdateRedeemEcoupon,
 } from './atomic-operations';
-import AtomicOperations from './atomic-operations';
 import {BaseEventHandlerOpts} from './types';
 import {collectPointsAccountSnapshotsFromAtomicOperations} from './collect-points-account-snapshots';
 

--- a/src/ee-air/posconnect-wallet-settle.ts
+++ b/src/ee-air/posconnect-wallet-settle.ts
@@ -1,8 +1,4 @@
-import {
-  EeAirOutboundEvent,
-  TierAttributes,
-  TransactionAttributes,
-} from '..';
+import {EeAirOutboundEvent, TierAttributes, TransactionAttributes} from '..';
 import {
   CouponWithValueAttributes,
   POSConnectWalletSettleEventData,

--- a/src/ee-air/posconnect-wallet-settle.ts
+++ b/src/ee-air/posconnect-wallet-settle.ts
@@ -1,6 +1,5 @@
 import {
   EeAirOutboundEvent,
-  PointsAttributes,
   TierAttributes,
   TransactionAttributes,
 } from '..';
@@ -12,11 +11,10 @@ import {isTierMembershipEntity} from './atomic-operations';
 import {
   isWalletTransactionEntityUpdateSettleSettled,
   isWalletAccountTransactionEntityUpdateRedeemEcoupon,
-  isWalletAccountTransactionEntityUpdatePoints,
 } from './atomic-operations';
 import AtomicOperations from './atomic-operations';
 import {BaseEventHandlerOpts} from './types';
-import {getPointsAttributesFromWalletAccountTransactionEntity} from './atomic-operations/wallet-account-transaction-entity';
+import {collectPointsAccountSnapshotsFromAtomicOperations} from './collect-points-account-snapshots';
 
 /**
  * Returns an array of events derived from a POSCONNECT.WALLET.SETTLE event.
@@ -29,25 +27,19 @@ export function getPosConnectWalletSettleEventData(
   event: EeAirOutboundEvent,
   opts: BaseEventHandlerOpts,
 ): POSConnectWalletSettleEventData {
+  const {pointsAccounts, points} =
+    collectPointsAccountSnapshotsFromAtomicOperations(
+      event.atomicOperations,
+      'pointsUpdatesOnly',
+    );
+
   let transactionAttributes: TransactionAttributes | null = null;
-  let pointsAttributes: PointsAttributes | null = null;
   let tierAttributes: TierAttributes | null = null;
 
   const redeemedCoupons: CouponWithValueAttributes[] = [];
 
   for (const op of event.atomicOperations) {
-    if (isWalletAccountTransactionEntityUpdatePoints(op)) {
-      // Always take the latest POINTS balance observed in the operations list
-      try {
-        pointsAttributes =
-          getPointsAttributesFromWalletAccountTransactionEntity(op as any);
-      } catch {
-        // Ignore if balance not available on this op.
-        // By taking the latest POINTS balance observed in the operations list,
-        // we ensure that we always have the most up-to-date balance regardless
-        // of the its type.
-      }
-    } else if (isTierMembershipEntity(op)) {
+    if (isTierMembershipEntity(op)) {
       tierAttributes =
         AtomicOperations.TierMembershipEntity.getTierAttributes(op);
     } else if (isWalletAccountTransactionEntityUpdateRedeemEcoupon(op)) {
@@ -71,7 +63,8 @@ export function getPosConnectWalletSettleEventData(
   }
 
   const posConnectWalletSettleEventData: POSConnectWalletSettleEventData = {
-    ...(pointsAttributes ? {points: pointsAttributes} : {}),
+    ...(pointsAccounts.length > 0 ? {pointsAccounts} : {}),
+    ...(points ? {points} : {}),
     ...(tierAttributes ? {tier: tierAttributes} : {}),
     ...(transactionAttributes ? {transaction: transactionAttributes} : {}),
     redeemedCoupons,

--- a/src/ee-air/posconnect-wallet-settle.ts
+++ b/src/ee-air/posconnect-wallet-settle.ts
@@ -9,7 +9,7 @@ import AtomicOperations, {
   isWalletAccountTransactionEntityUpdateRedeemEcoupon,
 } from './atomic-operations';
 import {BaseEventHandlerOpts} from './types';
-import {collectPointsAccountSnapshotsFromAtomicOperations} from './collect-points-account-snapshots';
+import {pointsSnapshotFieldsForEvent} from './collect-points-account-snapshots';
 
 /**
  * Returns an array of events derived from a POSCONNECT.WALLET.SETTLE event.
@@ -22,12 +22,6 @@ export function getPosConnectWalletSettleEventData(
   event: EeAirOutboundEvent,
   opts: BaseEventHandlerOpts,
 ): POSConnectWalletSettleEventData {
-  const {pointsAccounts, points} =
-    collectPointsAccountSnapshotsFromAtomicOperations(
-      event.atomicOperations,
-      'pointsUpdatesOnly',
-    );
-
   let transactionAttributes: TransactionAttributes | null = null;
   let tierAttributes: TierAttributes | null = null;
 
@@ -58,8 +52,10 @@ export function getPosConnectWalletSettleEventData(
   }
 
   const posConnectWalletSettleEventData: POSConnectWalletSettleEventData = {
-    ...(pointsAccounts.length > 0 ? {pointsAccounts} : {}),
-    ...(points ? {points} : {}),
+    ...pointsSnapshotFieldsForEvent(
+      event.atomicOperations,
+      'pointsUpdatesOnly',
+    ),
     ...(tierAttributes ? {tier: tierAttributes} : {}),
     ...(transactionAttributes ? {transaction: transactionAttributes} : {}),
     redeemedCoupons,

--- a/src/ee-air/posconnect-wallet-spend-void.ts
+++ b/src/ee-air/posconnect-wallet-spend-void.ts
@@ -1,8 +1,9 @@
 import {EeAirOutboundEvent, EeAirClient} from '..';
 import {POSConnectWalletSpendVoidEventData} from '../types';
 import {BaseEventHandlerOpts} from './types';
-import {isWalletTransactionEntityUpdateSpendVoided} from './atomic-operations';
-import AtomicOperations from './atomic-operations';
+import AtomicOperations, {
+  isWalletTransactionEntityUpdateSpendVoided,
+} from './atomic-operations';
 import {collectPointsAccountSnapshotsFromAtomicOperations} from './collect-points-account-snapshots';
 
 /**

--- a/src/ee-air/posconnect-wallet-spend-void.ts
+++ b/src/ee-air/posconnect-wallet-spend-void.ts
@@ -1,11 +1,9 @@
 import {EeAirOutboundEvent, EeAirClient} from '..';
 import {POSConnectWalletSpendVoidEventData} from '../types';
 import {BaseEventHandlerOpts} from './types';
-import {
-  isWalletAccountTransactionEntityUpdatePoints,
-  isWalletTransactionEntityUpdateSpendVoided,
-} from './atomic-operations';
+import {isWalletTransactionEntityUpdateSpendVoided} from './atomic-operations';
 import AtomicOperations from './atomic-operations';
+import {collectPointsAccountSnapshotsFromAtomicOperations} from './collect-points-account-snapshots';
 
 /**
  * Returns an array of events derived from a POSCONNECT.WALLET.SETTLE event.
@@ -18,18 +16,21 @@ export async function getPosConnectWalletSpendVoidEventData(
   event: EeAirOutboundEvent,
   opts: BaseEventHandlerOpts,
 ): Promise<POSConnectWalletSpendVoidEventData> {
+  const {pointsAccounts, points} =
+    collectPointsAccountSnapshotsFromAtomicOperations(
+      event.atomicOperations,
+      'pointsUpdatesOnly',
+    );
+
   const posConnectWalletSpendVoidEventData: POSConnectWalletSpendVoidEventData =
     {
       voided: true,
+      ...(pointsAccounts.length > 0 ? {pointsAccounts} : {}),
+      ...(points ? {points} : {}),
     };
 
   for (const op of event.atomicOperations) {
-    if (isWalletAccountTransactionEntityUpdatePoints(op)) {
-      posConnectWalletSpendVoidEventData.points =
-        AtomicOperations.WalletAccountTransactionEntity.UpdateEarnPoints.getPointsAttributes(
-          op,
-        );
-    } else if (isWalletTransactionEntityUpdateSpendVoided(op)) {
+    if (isWalletTransactionEntityUpdateSpendVoided(op)) {
       posConnectWalletSpendVoidEventData.transaction =
         AtomicOperations.WalletTransactionEntity.UpdateSpendVoid.getTransactionAttributes(
           op,

--- a/src/ee-air/posconnect-wallet-spend-void.ts
+++ b/src/ee-air/posconnect-wallet-spend-void.ts
@@ -4,7 +4,7 @@ import {BaseEventHandlerOpts} from './types';
 import AtomicOperations, {
   isWalletTransactionEntityUpdateSpendVoided,
 } from './atomic-operations';
-import {collectPointsAccountSnapshotsFromAtomicOperations} from './collect-points-account-snapshots';
+import {pointsSnapshotFieldsForEvent} from './collect-points-account-snapshots';
 
 /**
  * Returns an array of events derived from a POSCONNECT.WALLET.SETTLE event.
@@ -17,17 +17,13 @@ export async function getPosConnectWalletSpendVoidEventData(
   event: EeAirOutboundEvent,
   opts: BaseEventHandlerOpts,
 ): Promise<POSConnectWalletSpendVoidEventData> {
-  const {pointsAccounts, points} =
-    collectPointsAccountSnapshotsFromAtomicOperations(
-      event.atomicOperations,
-      'pointsUpdatesOnly',
-    );
-
   const posConnectWalletSpendVoidEventData: POSConnectWalletSpendVoidEventData =
     {
       voided: true,
-      ...(pointsAccounts.length > 0 ? {pointsAccounts} : {}),
-      ...(points ? {points} : {}),
+      ...pointsSnapshotFieldsForEvent(
+        event.atomicOperations,
+        'pointsUpdatesOnly',
+      ),
     };
 
   for (const op of event.atomicOperations) {

--- a/src/ee-air/posconnect-wallet-spend.ts
+++ b/src/ee-air/posconnect-wallet-spend.ts
@@ -1,10 +1,8 @@
 import {EeAirOutboundEvent} from '..';
 import {POSConnectWalletSpendEventData} from '../types';
-import {
-  isWalletAccountTransactionEntityUpdatePoints,
-  isWalletTransactionEntityUpdateSpend,
-} from './atomic-operations';
+import {isWalletTransactionEntityUpdateSpend} from './atomic-operations';
 import AtomicOperations from './atomic-operations';
+import {collectPointsAccountSnapshotsFromAtomicOperations} from './collect-points-account-snapshots';
 
 /**
  * Returns an array of events derived from a POSCONNECT.WALLET.SETTLE event.
@@ -16,15 +14,19 @@ import AtomicOperations from './atomic-operations';
 export function getPosConnectWalletSpendEventData(
   event: EeAirOutboundEvent,
 ): POSConnectWalletSpendEventData {
-  const posConnectWalletSpendEventData: POSConnectWalletSpendEventData = {};
+  const {pointsAccounts, points} =
+    collectPointsAccountSnapshotsFromAtomicOperations(
+      event.atomicOperations,
+      'pointsUpdatesOnly',
+    );
+
+  const posConnectWalletSpendEventData: POSConnectWalletSpendEventData = {
+    ...(pointsAccounts.length > 0 ? {pointsAccounts} : {}),
+    ...(points ? {points} : {}),
+  };
 
   for (const op of event.atomicOperations) {
-    if (isWalletAccountTransactionEntityUpdatePoints(op)) {
-      posConnectWalletSpendEventData.points =
-        AtomicOperations.WalletAccountTransactionEntity.UpdateEarnPoints.getPointsAttributes(
-          op,
-        );
-    } else if (isWalletTransactionEntityUpdateSpend(op)) {
+    if (isWalletTransactionEntityUpdateSpend(op)) {
       posConnectWalletSpendEventData.transaction =
         AtomicOperations.WalletTransactionEntity.UpdateSpend.getTransactionAttributes(
           op,

--- a/src/ee-air/posconnect-wallet-spend.ts
+++ b/src/ee-air/posconnect-wallet-spend.ts
@@ -3,7 +3,7 @@ import {POSConnectWalletSpendEventData} from '../types';
 import AtomicOperations, {
   isWalletTransactionEntityUpdateSpend,
 } from './atomic-operations';
-import {collectPointsAccountSnapshotsFromAtomicOperations} from './collect-points-account-snapshots';
+import {pointsSnapshotFieldsForEvent} from './collect-points-account-snapshots';
 
 /**
  * Returns an array of events derived from a POSCONNECT.WALLET.SETTLE event.
@@ -15,15 +15,11 @@ import {collectPointsAccountSnapshotsFromAtomicOperations} from './collect-point
 export function getPosConnectWalletSpendEventData(
   event: EeAirOutboundEvent,
 ): POSConnectWalletSpendEventData {
-  const {pointsAccounts, points} =
-    collectPointsAccountSnapshotsFromAtomicOperations(
+  const posConnectWalletSpendEventData: POSConnectWalletSpendEventData = {
+    ...pointsSnapshotFieldsForEvent(
       event.atomicOperations,
       'pointsUpdatesOnly',
-    );
-
-  const posConnectWalletSpendEventData: POSConnectWalletSpendEventData = {
-    ...(pointsAccounts.length > 0 ? {pointsAccounts} : {}),
-    ...(points ? {points} : {}),
+    ),
   };
 
   for (const op of event.atomicOperations) {

--- a/src/ee-air/posconnect-wallet-spend.ts
+++ b/src/ee-air/posconnect-wallet-spend.ts
@@ -1,7 +1,8 @@
 import {EeAirOutboundEvent} from '..';
 import {POSConnectWalletSpendEventData} from '../types';
-import {isWalletTransactionEntityUpdateSpend} from './atomic-operations';
-import AtomicOperations from './atomic-operations';
+import AtomicOperations, {
+  isWalletTransactionEntityUpdateSpend,
+} from './atomic-operations';
 import {collectPointsAccountSnapshotsFromAtomicOperations} from './collect-points-account-snapshots';
 
 /**

--- a/src/ee-air/service-trigger.ts
+++ b/src/ee-air/service-trigger.ts
@@ -1,8 +1,6 @@
 import {EeAirOutboundEvent} from '..';
 import {ServiceTriggerEventData} from '../types';
 import {
-  isWalletAccountTransactionEntityCreatePoints,
-  getPointsAttributesFromWalletAccountTransactionEntity,
   isTierMembershipEntityUpdate,
   getTierAttributesFromTierMembershipEntity,
   getBehavioralActionAttributesFromWalletAccountTransactionEntity,
@@ -10,6 +8,7 @@ import {
   getCouponAttributesFromWalletAccountTransactionEntity,
   isWalletAccountTransactionEntityCreateEcoupon,
 } from './atomic-operations';
+import {collectPointsAccountSnapshotsFromAtomicOperations} from './collect-points-account-snapshots';
 
 /**
  * Returns data extracted from a SERVICE.TRIGGER event.
@@ -20,15 +19,20 @@ import {
 export function getServiceTriggerEventData(
   event: EeAirOutboundEvent,
 ): ServiceTriggerEventData {
+  const {pointsAccounts, points} =
+    collectPointsAccountSnapshotsFromAtomicOperations(
+      event.atomicOperations,
+      'pointsCreatesOnly',
+    );
+
   const eventData: ServiceTriggerEventData = {
     awardedCoupons: [],
+    ...(pointsAccounts.length > 0 ? {pointsAccounts} : {}),
+    ...(points ? {points} : {}),
   };
 
   for (const op of event.atomicOperations) {
-    if (isWalletAccountTransactionEntityCreatePoints(op)) {
-      eventData.points =
-        getPointsAttributesFromWalletAccountTransactionEntity(op);
-    } else if (isTierMembershipEntityUpdate(op)) {
+    if (isTierMembershipEntityUpdate(op)) {
       eventData.tier = getTierAttributesFromTierMembershipEntity(op);
     } else if (isWalletAccountTransactionEntityRedeemBehavioralAction(op)) {
       eventData.awardedPoints =

--- a/src/ee-air/service-trigger.ts
+++ b/src/ee-air/service-trigger.ts
@@ -8,7 +8,7 @@ import {
   getCouponAttributesFromWalletAccountTransactionEntity,
   isWalletAccountTransactionEntityCreateEcoupon,
 } from './atomic-operations';
-import {collectPointsAccountSnapshotsFromAtomicOperations} from './collect-points-account-snapshots';
+import {pointsSnapshotFieldsForEvent} from './collect-points-account-snapshots';
 
 /**
  * Returns data extracted from a SERVICE.TRIGGER event.
@@ -19,16 +19,12 @@ import {collectPointsAccountSnapshotsFromAtomicOperations} from './collect-point
 export function getServiceTriggerEventData(
   event: EeAirOutboundEvent,
 ): ServiceTriggerEventData {
-  const {pointsAccounts, points} =
-    collectPointsAccountSnapshotsFromAtomicOperations(
-      event.atomicOperations,
-      'pointsCreatesOnly',
-    );
-
   const eventData: ServiceTriggerEventData = {
     awardedCoupons: [],
-    ...(pointsAccounts.length > 0 ? {pointsAccounts} : {}),
-    ...(points ? {points} : {}),
+    ...pointsSnapshotFieldsForEvent(
+      event.atomicOperations,
+      'pointsCreatesOnly',
+    ),
   };
 
   for (const op of event.atomicOperations) {

--- a/src/ee-air/service-wallet-accounts-create.ts
+++ b/src/ee-air/service-wallet-accounts-create.ts
@@ -14,24 +14,20 @@ import {
   isWalletAccountTransactionEntityCreateQuest,
   isWalletAccountTransactionEntityCreateStampCard,
 } from './atomic-operations';
-import {collectPointsAccountSnapshotsFromAtomicOperations} from './collect-points-account-snapshots';
+import {pointsSnapshotFieldsForEvent} from './collect-points-account-snapshots';
 
 export function getServiceWalletAccountsCreateEventData(
   eeAirOutboundEvent: EeAirOutboundEvent,
 ): ServiceWalletAccountsCreateEventData {
-  const {pointsAccounts, points} =
-    collectPointsAccountSnapshotsFromAtomicOperations(
-      eeAirOutboundEvent.atomicOperations,
-      'pointsCreatesOnly',
-    );
-
   const eventData: ServiceWalletAccountsCreateEventData = {
     coupons: [],
     continuityAccounts: [],
     questAccounts: [],
     stampCards: [],
-    ...(pointsAccounts.length > 0 ? {pointsAccounts} : {}),
-    ...(points ? {points} : {}),
+    ...pointsSnapshotFieldsForEvent(
+      eeAirOutboundEvent.atomicOperations,
+      'pointsCreatesOnly',
+    ),
   };
 
   for (const op of eeAirOutboundEvent.atomicOperations) {

--- a/src/ee-air/service-wallet-accounts-create.ts
+++ b/src/ee-air/service-wallet-accounts-create.ts
@@ -4,35 +4,39 @@ import {
 } from '../types';
 import {
   getCouponAttributesFromWalletAccountTransactionEntity,
-  getPointsAttributesFromWalletAccountTransactionEntity,
   getTierAttributesFromTierMembershipEntity,
   getContinuityAttributesFromWalletAccountTransactionEntity,
   getQuestAttributesFromWalletAccountTransactionEntity,
   getStampCardAttributesFromWalletAccountTransactionEntity,
   isTierMembershipEntity,
   isWalletAccountTransactionEntityCreateEcoupon,
-  isWalletAccountTransactionEntityCreatePoints,
   isWalletAccountTransactionEntityCreateContinuity,
   isWalletAccountTransactionEntityCreateQuest,
   isWalletAccountTransactionEntityCreateStampCard,
 } from './atomic-operations';
+import {collectPointsAccountSnapshotsFromAtomicOperations} from './collect-points-account-snapshots';
 
 export function getServiceWalletAccountsCreateEventData(
   eeAirOutboundEvent: EeAirOutboundEvent,
 ): ServiceWalletAccountsCreateEventData {
+  const {pointsAccounts, points} =
+    collectPointsAccountSnapshotsFromAtomicOperations(
+      eeAirOutboundEvent.atomicOperations,
+      'pointsCreatesOnly',
+    );
+
   const eventData: ServiceWalletAccountsCreateEventData = {
     coupons: [],
     continuityAccounts: [],
     questAccounts: [],
     stampCards: [],
+    ...(pointsAccounts.length > 0 ? {pointsAccounts} : {}),
+    ...(points ? {points} : {}),
   };
 
   for (const op of eeAirOutboundEvent.atomicOperations) {
     if (isTierMembershipEntity(op)) {
       eventData.tier = getTierAttributesFromTierMembershipEntity(op);
-    } else if (isWalletAccountTransactionEntityCreatePoints(op)) {
-      eventData.points =
-        getPointsAttributesFromWalletAccountTransactionEntity(op);
     } else if (isWalletAccountTransactionEntityCreateEcoupon(op)) {
       const coupon = getCouponAttributesFromWalletAccountTransactionEntity(op);
       eventData.coupons.push(coupon);

--- a/src/ee-air/service-wallet-create.ts
+++ b/src/ee-air/service-wallet-create.ts
@@ -1,7 +1,7 @@
 import {EeAirOutboundEvent, ServiceWalletCreateEventData} from '../types';
 
 export function getServiceWalletCreateEventData(
-  eeAirOutboundEvent: EeAirOutboundEvent,
+  _eeAirOutboundEvent: EeAirOutboundEvent,
 ): ServiceWalletCreateEventData {
   const eventData: ServiceWalletCreateEventData = {};
 

--- a/src/ee-air/wallet-account-create-scheme.ts
+++ b/src/ee-air/wallet-account-create-scheme.ts
@@ -4,7 +4,7 @@ import {
   isTierMembershipEntity,
   getTierAttributesFromTierMembershipEntity,
 } from './atomic-operations';
-import {collectPointsAccountSnapshotsFromAtomicOperations} from './collect-points-account-snapshots';
+import {pointsSnapshotFieldsForEvent} from './collect-points-account-snapshots';
 
 /**
  * Returns an array of events derived from a WALLET.ACCOUNT.CREATE.SCHEME event.
@@ -16,15 +16,11 @@ import {collectPointsAccountSnapshotsFromAtomicOperations} from './collect-point
 export function getWalletAccountCreateSchemeEventData(
   event: EeAirOutboundEvent,
 ): WalletAccountCreateSchemeEventData {
-  const {pointsAccounts, points} =
-    collectPointsAccountSnapshotsFromAtomicOperations(
+  const eventData: WalletAccountCreateSchemeEventData = {
+    ...pointsSnapshotFieldsForEvent(
       event.atomicOperations,
       'pointsCreatesOnly',
-    );
-
-  const eventData: WalletAccountCreateSchemeEventData = {
-    ...(pointsAccounts.length > 0 ? {pointsAccounts} : {}),
-    ...(points ? {points} : {}),
+    ),
   };
 
   for (const op of event.atomicOperations) {

--- a/src/ee-air/wallet-account-create-scheme.ts
+++ b/src/ee-air/wallet-account-create-scheme.ts
@@ -3,9 +3,8 @@ import {WalletAccountCreateSchemeEventData} from '../types';
 import {
   isTierMembershipEntity,
   getTierAttributesFromTierMembershipEntity,
-  isWalletAccountTransactionEntityCreatePoints,
-  getPointsAttributesFromWalletAccountTransactionEntity,
 } from './atomic-operations';
+import {collectPointsAccountSnapshotsFromAtomicOperations} from './collect-points-account-snapshots';
 
 /**
  * Returns an array of events derived from a WALLET.ACCOUNT.CREATE.SCHEME event.
@@ -17,14 +16,20 @@ import {
 export function getWalletAccountCreateSchemeEventData(
   event: EeAirOutboundEvent,
 ): WalletAccountCreateSchemeEventData {
-  const eventData: WalletAccountCreateSchemeEventData = {};
+  const {pointsAccounts, points} =
+    collectPointsAccountSnapshotsFromAtomicOperations(
+      event.atomicOperations,
+      'pointsCreatesOnly',
+    );
+
+  const eventData: WalletAccountCreateSchemeEventData = {
+    ...(pointsAccounts.length > 0 ? {pointsAccounts} : {}),
+    ...(points ? {points} : {}),
+  };
 
   for (const op of event.atomicOperations) {
     if (isTierMembershipEntity(op)) {
       eventData.tier = getTierAttributesFromTierMembershipEntity(op);
-    } else if (isWalletAccountTransactionEntityCreatePoints(op)) {
-      eventData.points =
-        getPointsAttributesFromWalletAccountTransactionEntity(op);
     }
   }
 

--- a/src/types/ee-air/index.ts
+++ b/src/types/ee-air/index.ts
@@ -1,5 +1,6 @@
 import {
   PointsAttributes,
+  PointsAccountSnapshot,
   TierAttributes,
   TransactionAttributes,
   CouponAttributes,
@@ -46,6 +47,10 @@ export type POSConnectWalletSettleEventData = {
   questRedemption?: QuestAttributes[];
   stampCardProgression?: StampCardAttributes[];
   stampCardRedemption?: StampCardAttributes[];
+  /**
+   * Per POINTS account balances after this event (multi-scheme).
+   */
+  pointsAccounts?: PointsAccountSnapshot[];
   points?: PointsAttributes;
   tier?: TierAttributes;
   transaction?: TransactionAttributes;
@@ -58,6 +63,7 @@ export type POSConnectWalletSettleEventData = {
  * is made available to connectors via the getPosConnectWalletFulfilEventData API.
  */
 export type POSConnectWalletFulfilEventData = {
+  pointsAccounts?: PointsAccountSnapshot[];
   points?: PointsAttributes;
   tier?: TierAttributes;
   transaction?: TransactionAttributes;
@@ -72,6 +78,7 @@ export type POSConnectWalletFulfilEventData = {
  * is made available to connectors via the getPosConnectWalletRefundEventData API.
  */
 export type POSConnectWalletRefundEventData = {
+  pointsAccounts?: PointsAccountSnapshot[];
   points?: PointsAttributes;
   tier?: TierAttributes;
   transaction?: TransactionAttributes;
@@ -85,6 +92,7 @@ export type POSConnectWalletRefundEventData = {
  * is made available to connectors via the getPosConnectWalletSpendEventData API.
  */
 export type POSConnectWalletSpendEventData = {
+  pointsAccounts?: PointsAccountSnapshot[];
   points?: PointsAttributes;
   tier?: number;
   transaction?: SpendTransactionAttributes;
@@ -137,6 +145,10 @@ export type WalletAccountUpdateEventData = {
  */
 export type WalletAccountCreateSchemeEventData = {
   /**
+   * Per POINTS account balances after scheme account creation (multi-scheme).
+   */
+  pointsAccounts?: PointsAccountSnapshot[];
+  /**
    * Points account balance, if available.
    */
   points?: PointsAttributes;
@@ -175,6 +187,10 @@ export type WalletAccountCreateCampaignEventData = {
 
 export type ServiceTriggerEventData = {
   /**
+   * Per POINTS account balances after the trigger (multi-scheme).
+   */
+  pointsAccounts?: PointsAccountSnapshot[];
+  /**
    * New points balances.
    */
   points?: PointsAttributes;
@@ -198,6 +214,10 @@ export type ServiceTriggerEventData = {
 export type ServiceWalletCreateEventData = {};
 
 export type ServiceWalletAccountsCreateEventData = {
+  /**
+   * Per POINTS account created or updated in this event (multi-scheme).
+   */
+  pointsAccounts?: PointsAccountSnapshot[];
   /**
    * New points balances.
    */

--- a/src/types/ee-air/outbound/atomic-operations/types.ts
+++ b/src/types/ee-air/outbound/atomic-operations/types.ts
@@ -2,6 +2,24 @@ export type PointsAttributes = {
   pointsBalance: number;
 };
 
+/**
+ * Full snapshot of a POINTS wallet account from AIR atomic operations, used for
+ * multi-scheme loyalty (one wallet may have multiple POINTS accounts).
+ *
+ * Legacy {@link PointsAttributes} remains the balance-only shape; use
+ * `legacyPointsFromLastPointsOperation` to derive the historical single-field balance.
+ */
+export type PointsAccountSnapshot = {
+  accountId: string;
+  campaignId: string;
+  walletId: string;
+  pointsBalance: number;
+  type: string;
+  clientType: string | null;
+  status: string;
+  state: string;
+};
+
 export type RedeemedBehavioralActionAttributes = {
   points: number;
   accountId: string;

--- a/test/jest.setup.ts
+++ b/test/jest.setup.ts
@@ -1,0 +1,10 @@
+jest.mock('newrelic', () => ({
+  addCustomAttribute: jest.fn(),
+  startWebTransaction: jest.fn(),
+  getTransaction: jest.fn(),
+  endTransaction: jest.fn(),
+  addCustomAttributes: jest.fn(),
+  noticeError: jest.fn(),
+  getBrowserTimingHeader: jest.fn(),
+  shutdown: jest.fn(),
+}));

--- a/test/unit/ee-air/collect-points-account-snapshots.spec.ts
+++ b/test/unit/ee-air/collect-points-account-snapshots.spec.ts
@@ -1,0 +1,35 @@
+import {
+  EeAirOutboundEventSchema,
+  collectPointsAccountSnapshotsFromAtomicOperations,
+} from '../../../src';
+import {sampleEvents} from '../../fixtures';
+
+describe('collectPointsAccountSnapshotsFromAtomicOperations', () => {
+  it('dedupes multiple UPDATE POINTS ops for the same account (last wins)', () => {
+    const event = EeAirOutboundEventSchema.parse(
+      sampleEvents.POSCONNECT_WALLET_SETTLE,
+    );
+    const {pointsAccounts, points} =
+      collectPointsAccountSnapshotsFromAtomicOperations(
+        event.atomicOperations,
+        'pointsUpdatesOnly',
+      );
+    expect(pointsAccounts).toHaveLength(1);
+    expect(pointsAccounts[0].accountId).toBe('4093853182');
+    expect(pointsAccounts[0].pointsBalance).toBe(663);
+    expect(points?.pointsBalance).toBe(663);
+  });
+
+  it('collects multiple distinct POINTS accounts on SERVICE.WALLET.ACCOUNTS.CREATE', () => {
+    const event = EeAirOutboundEventSchema.parse(
+      sampleEvents.SERVICE_WALLET_ACCOUNTS_CREATE,
+    );
+    const {pointsAccounts, points} =
+      collectPointsAccountSnapshotsFromAtomicOperations(
+        event.atomicOperations,
+        'pointsCreatesOnly',
+      );
+    expect(pointsAccounts).toHaveLength(1);
+    expect(points?.pointsBalance).toBe(0);
+  });
+});

--- a/test/unit/ee-air/posconnect-wallet-fulfil.spec.ts
+++ b/test/unit/ee-air/posconnect-wallet-fulfil.spec.ts
@@ -120,6 +120,18 @@ describe('getPosConnectWalletFulfilEventData', () => {
       eventName: 'POSCONNECT.WALLET.FULFIL (final)',
       event: sampleEvents.POSCONNECT_WALLET_FULFIL_FINAL,
       expectedOutput: {
+        pointsAccounts: [
+          {
+            accountId: '4102294539',
+            campaignId: '100620987',
+            walletId: '216418806',
+            pointsBalance: 1389,
+            type: 'POINTS',
+            clientType: 'RETAILPOINTS',
+            status: 'ACTIVE',
+            state: 'LOADED',
+          },
+        ],
         points: {
           pointsBalance: 1389,
         },

--- a/test/unit/ee-air/posconnect-wallet-refund.spec.ts
+++ b/test/unit/ee-air/posconnect-wallet-refund.spec.ts
@@ -19,6 +19,18 @@ describe('getPosConnectWalletRefundEventData', () => {
       eventName: 'POSCONNECT.WALLET.REFUND (partial)',
       event: sampleEvents.POSCONNECT_WALLET_REFUND_PARTIAL,
       expectedOutput: {
+        pointsAccounts: [
+          {
+            accountId: '4102294539',
+            campaignId: '100620987',
+            walletId: '216418806',
+            pointsBalance: 1371,
+            type: 'POINTS',
+            clientType: 'RETAILPOINTS',
+            status: 'ACTIVE',
+            state: 'LOADED',
+          },
+        ],
         points: {
           pointsBalance: 1371,
         },
@@ -83,6 +95,18 @@ describe('getPosConnectWalletRefundEventData', () => {
       eventName: 'POSCONNECT.WALLET.REFUND (full)',
       event: sampleEvents.POSCONNECT_WALLET_REFUND_FULL,
       expectedOutput: {
+        pointsAccounts: [
+          {
+            accountId: '4102294539',
+            campaignId: '100620987',
+            walletId: '216418806',
+            pointsBalance: 1326,
+            type: 'POINTS',
+            clientType: 'RETAILPOINTS',
+            status: 'ACTIVE',
+            state: 'LOADED',
+          },
+        ],
         points: {
           pointsBalance: 1326,
         },

--- a/test/unit/ee-air/posconnect-wallet-settle.spec.ts
+++ b/test/unit/ee-air/posconnect-wallet-settle.spec.ts
@@ -28,6 +28,18 @@ describe('getPosConnectWalletSettleEventData', () => {
 
     const expectedOutput: POSConnectWalletSettleEventData = {
       currencyCode: 'USD',
+      pointsAccounts: [
+        {
+          accountId: '4093853182',
+          campaignId: '100620987',
+          walletId: '216396239',
+          pointsBalance: 663,
+          type: 'POINTS',
+          clientType: 'RETAILPOINTS',
+          status: 'ACTIVE',
+          state: 'LOADED',
+        },
+      ],
       redeemedCoupons: [
         {
           accountId: '4093853356',

--- a/test/unit/ee-air/posconnect-wallet-spend-void.spec.ts
+++ b/test/unit/ee-air/posconnect-wallet-spend-void.spec.ts
@@ -46,6 +46,18 @@ describe('getPosConnectWalletSpendVoidEventData', () => {
     });
 
     const expectedOutput: POSConnectWalletSpendVoidEventData = {
+      pointsAccounts: [
+        {
+          accountId: '4083750463',
+          campaignId: '100620987',
+          walletId: '216245571',
+          pointsBalance: 56340,
+          type: 'POINTS',
+          clientType: 'RETAILPOINTS',
+          status: 'ACTIVE',
+          state: 'LOADED',
+        },
+      ],
       points: {
         pointsBalance: 56340,
       },

--- a/test/unit/ee-air/posconnect-wallet-spend.spec.ts
+++ b/test/unit/ee-air/posconnect-wallet-spend.spec.ts
@@ -13,6 +13,18 @@ describe('getPosConnectWalletSpendEventData', () => {
     );
 
     const expectedOutput: POSConnectWalletSpendEventData = {
+      pointsAccounts: [
+        {
+          accountId: '4083750463',
+          campaignId: '100620987',
+          walletId: '216245571',
+          pointsBalance: 25670,
+          type: 'POINTS',
+          clientType: 'RETAILPOINTS',
+          status: 'ACTIVE',
+          state: 'LOADED',
+        },
+      ],
       points: {
         pointsBalance: 25670,
       },

--- a/test/unit/ee-air/service-trigger.spec.ts
+++ b/test/unit/ee-air/service-trigger.spec.ts
@@ -57,6 +57,18 @@ describe('getServiceTriggerData', () => {
     );
 
     const expectedOutput: ServiceTriggerEventData = {
+      pointsAccounts: [
+        {
+          accountId: '4102305275',
+          campaignId: '100620987',
+          walletId: '216419576',
+          pointsBalance: 400,
+          type: 'POINTS',
+          clientType: 'RETAILPOINTS',
+          status: 'ACTIVE',
+          state: 'LOADED',
+        },
+      ],
       points: {
         pointsBalance: 400,
       },

--- a/test/unit/ee-air/service-wallet-accounts-create.spec.ts
+++ b/test/unit/ee-air/service-wallet-accounts-create.spec.ts
@@ -14,6 +14,18 @@ describe('getServiceWalletAccountsCreateEventData', () => {
     );
 
     const expectedOutput: ServiceWalletAccountsCreateEventData = {
+      pointsAccounts: [
+        {
+          accountId: '4093853182',
+          campaignId: '100620987',
+          walletId: '216396239',
+          pointsBalance: 0,
+          type: 'POINTS',
+          clientType: 'RETAILPOINTS',
+          status: 'ACTIVE',
+          state: 'LOADED',
+        },
+      ],
       points: {
         pointsBalance: 0,
       },

--- a/test/unit/ee-air/wallet-account-create-scheme.spec.ts
+++ b/test/unit/ee-air/wallet-account-create-scheme.spec.ts
@@ -13,6 +13,18 @@ describe('getWalletAccountCreateSchemeEventData', () => {
     );
 
     const expectedOutput: WalletAccountCreateSchemeEventData = {
+      pointsAccounts: [
+        {
+          accountId: '4093853258',
+          campaignId: '100620987',
+          walletId: '216396269',
+          pointsBalance: 0,
+          type: 'POINTS',
+          clientType: 'RETAILPOINTS',
+          status: 'ACTIVE',
+          state: 'EARNBURN',
+        },
+      ],
       points: {
         pointsBalance: 0,
       },


### PR DESCRIPTION
This allows us to provide per-account points balances and data within each of the connectors.

- `PointsAccountSnapshot` and `getPointsAccountSnapshotFromWalletAccountTransactionEntity` for per–POINTS-account data (multi–loyalty-scheme).
- `collectPointsAccountSnapshotsFromAtomicOperations` to dedupe snapshots by `accountId` (last occurrence in event order wins per account) and derive legacy `points` as the **sum** of those per-account balances (same as the prior single-field value when only one POINTS account is present).
- `pointsAccounts` on `POSConnectWalletSettleEventData`, `POSConnectWalletFulfilEventData`, `POSConnectWalletRefundEventData`, `POSConnectWalletSpendEventData`, `WalletAccountCreateSchemeEventData`, `ServiceTriggerEventData`, and `ServiceWalletAccountsCreateEventData`.